### PR TITLE
Keep environment variables on windows

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -9,8 +9,11 @@ godot_bin_path = "../godot_fork/bin/"
 # for windows
 godot_lib_path = "../godot_fork/bin/"
 
-
+# This makes sure to keep the session environment variables on windows, 
+# that way you can run scons in a vs 2017 prompt and it will find all the required tools
 env = Environment()
+if platform == "windows":
+    env = Environment(ENV = os.environ)
 
 if ARGUMENTS.get("use_llvm", "no") == "yes":
     env["CXX"] = "clang++"


### PR DESCRIPTION
This ensures that environment variables are kept when on windows meaning you can run it with any version of VS, so long as you are in a VS prompt or have run the vcvars.bat file for your architecture